### PR TITLE
Add webrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 gem 'rack'
+gem 'webrick'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     rack (2.2.2)
     rake (13.0.1)
+    webrick (1.8.2)
 
 PLATFORMS
   ruby
@@ -10,4 +11,7 @@ PLATFORMS
 DEPENDENCIES
   rack
   rake
+  webrick
 
+BUNDLED WITH
+   2.5.23


### PR DESCRIPTION
When running locally with Ruby 3.3.1 I get an error:

```
⛄️ 3.3.1 🚀 /private/tmp/269ddedf70676c2d7e9a85ee2280722e/default_ruby (master)
$ bundle exec rackup
/Users/rschneeman/.gem/ruby/3.3.1/gems/rack-2.2.2/lib/rack/handler/webrick.rb:3: warning: webrick was loaded from the standard library, but is not part of the default gems since Ruby 3.0.0. Add webrick to your Gemfile or gemspec. Also contact author of rack-2.2.2 to add webrick into its gemspec.
bundler: failed to load command: rackup (/Users/rschneeman/.gem/ruby/3.3.1/bin/rackup)
/Users/rschneeman/.gem/ruby/3.3.1/gems/rack-2.2.2/lib/rack/handler.rb:45:in `pick': Couldn't find handler for: puma, thin, falcon, webrick. (LoadError)
```

Adding webrick fixes the problem